### PR TITLE
Fixes service provider name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ composer require cord/settings
 
 2. For Laravel <5.5 apps, add the service provider to your config/app.php file:
 ```
-Cord\Settings\SettingsServiceProvider::class,
+Cord\Settings\SettingServiceProvider::class,
 ```
 
 3. Publish files and run the migration.
 ```
-php artisan vendor:publish --provider="Cord\Settings\SettingsServiceProvider"
+php artisan vendor:publish --provider="Cord\Settings\SettingServiceProvider"
 php artisan migrate
 ```
 

--- a/src/SettingServiceProvider.php
+++ b/src/SettingServiceProvider.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Schema;
 use Cord\Settings\app\Models\Setting;
 use Route;
 
-class SettingsServiceProvider extends ServiceProvider
+class SettingServiceProvider extends ServiceProvider
 {
     /**
      * Indicates if loading of the provider is deferred.


### PR DESCRIPTION
After installing the package, I was hit with "Class 'Cord\Settings\SettingServiceProvider' not found" and it broke my app. This fixes it, as almost everywhere else it's singular, not plural.